### PR TITLE
Add export functionality for `DatabricksUser`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added DSC Export capability to `DatabricksResourceBase` class
+  - Added static `Export()` method to base class that provides guidance for
+    using the parameterized overload
+  - Added static `Export([FilteringInstance])` method that exports resources
+    with optional filtering based on instance properties
+  - Added virtual static methods `GetAllResourcesFromApi([Instance])` and
+    `CreateExportInstance([ApiData], [Instance])` that child classes override
+    to implement resource-specific export logic
+  - Implemented Export capability in `DatabricksUser` resource
+    - `GetAllResourcesFromApi()` retrieves all users from SCIM API endpoint
+      `/api/2.0/preview/scim/v2/Users`
+    - `CreateExportInstance()` converts API user data to `DatabricksUser`
+      instances with proper type conversion and sorting
+    - `Export([FilteringInstance])` supports filtering by UserName, DisplayName,
+      Active status, and other user properties
+  - Added comprehensive unit tests for Export functionality covering:
+    - API interaction and error handling
+    - Instance creation and property mapping
+    - Filtering logic with single and multiple filters
+    - Empty result handling
+- Improved unit test coverage for existing resources
+  - Added `BuildAccountUserPayload()` tests for `DatabricksAccountUser`
+  - Added error handling tests for `DatabricksAccountUser.Modify()` method
+    (create, update, and delete failure scenarios)
+  - Added `Test()` and `Set()` method tests for `DatabricksClusterPolicyPermission`
+  - Increased overall code coverage to ensure reliability
+
 ## [0.2.1] - 2025-11-19
 
 ### Added

--- a/source/en-US/DatabricksResourceBase.strings.psd1
+++ b/source/en-US/DatabricksResourceBase.strings.psd1
@@ -1,4 +1,10 @@
 ConvertFrom-StringData @'
     InvokingDatabricksApi = Invoking Databricks API: {0} {1}. (DRB0001)
     FailedToInvokeDatabricksApi = Failed to invoke Databricks API {0} {1}: {2}. (DRB0002)
+    ExportNotImplemented = Export functionality is not implemented for resource type {0}. (DRB0003)
+    ExportingResources = Exporting all {0} resources from Databricks workspace. (DRB0004)
+    ExportingResourcesFiltered = Exporting filtered {0} resources from Databricks workspace. (DRB0005)
+    NoResourcesFound = No {0} resources found in the Databricks workspace. (DRB0006)
+    ExportedResourceCount = Successfully exported {0} {1} resource(s). (DRB0007)
+    ExportFailed = Failed to export {0} resources: {1}. (DRB0008)
 '@

--- a/tests/Unit/Classes/DatabricksClusterPolicyPermission.Tests.ps1
+++ b/tests/Unit/Classes/DatabricksClusterPolicyPermission.Tests.ps1
@@ -126,6 +126,133 @@ Describe 'DatabricksClusterPolicyPermission\Get()' -Tag 'Get' {
     }
 }
 
+Describe 'DatabricksClusterPolicyPermission\Test()' -Tag 'Test' {
+    BeforeAll {
+        InModuleScope -ScriptBlock {
+            $script:mockInstance = [DatabricksClusterPolicyPermission] @{
+                WorkspaceUrl    = 'https://adb-1234567890123456.12.azuredatabricks.net'
+                AccessToken     = ConvertTo-SecureString -String 'dapi1234567890abcdef' -AsPlainText -Force
+                ClusterPolicyId = 'test-policy-123'
+            }
+        }
+    }
+
+    Context 'When the system is in the desired state' {
+        BeforeAll {
+            InModuleScope -ScriptBlock {
+                $script:mockInstance |
+                    Add-Member -Force -MemberType 'ScriptMethod' -Name 'Compare' -Value {
+                        return $null
+                    } -PassThru |
+                    Add-Member -Force -MemberType 'ScriptMethod' -Name 'AssertProperties' -Value {
+                        return
+                    }
+            }
+        }
+
+        It 'Should return $true' {
+            InModuleScope -ScriptBlock {
+                $script:mockInstance.Test() | Should -BeTrue
+            }
+        }
+    }
+
+    Context 'When the system is not in the desired state' {
+        BeforeAll {
+            InModuleScope -ScriptBlock {
+                $script:mockInstance |
+                    Add-Member -Force -MemberType 'ScriptMethod' -Name 'Compare' -Value {
+                        return @(
+                            @{
+                                Property      = 'AccessControlList'
+                                ExpectedValue = 'Expected'
+                                ActualValue   = 'Actual'
+                            }
+                        )
+                    } -PassThru |
+                    Add-Member -Force -MemberType 'ScriptMethod' -Name 'AssertProperties' -Value {
+                        return
+                    }
+            }
+        }
+
+        It 'Should return $false' {
+            InModuleScope -ScriptBlock {
+                $script:mockInstance.Test() | Should -BeFalse
+            }
+        }
+    }
+}
+
+Describe 'DatabricksClusterPolicyPermission\Set()' -Tag 'Set' {
+    BeforeAll {
+        InModuleScope -ScriptBlock {
+            $script:mockInstance = [DatabricksClusterPolicyPermission] @{
+                WorkspaceUrl    = 'https://adb-1234567890123456.12.azuredatabricks.net'
+                AccessToken     = ConvertTo-SecureString -String 'dapi1234567890abcdef' -AsPlainText -Force
+                ClusterPolicyId = 'test-policy-123'
+            } |
+                Add-Member -Force -MemberType 'ScriptMethod' -Name 'Modify' -Value {
+                    $script:mockMethodModifyCallCount += 1
+                } -PassThru
+        }
+    }
+
+    BeforeEach {
+        InModuleScope -ScriptBlock {
+            $script:mockMethodModifyCallCount = 0
+        }
+    }
+
+    Context 'When the system is in the desired state' {
+        BeforeAll {
+            InModuleScope -ScriptBlock {
+                $script:mockInstance |
+                    Add-Member -Force -MemberType 'ScriptMethod' -Name 'Compare' -Value {
+                        return $null
+                    } -PassThru |
+                    Add-Member -Force -MemberType 'ScriptMethod' -Name 'AssertProperties' -Value {
+                        return
+                    }
+            }
+        }
+
+        It 'Should not call method Modify()' {
+            InModuleScope -ScriptBlock {
+                $script:mockInstance.Set()
+
+                $script:mockMethodModifyCallCount | Should -Be 0
+            }
+        }
+    }
+
+    Context 'When the system is not in the desired state' {
+        BeforeAll {
+            InModuleScope -ScriptBlock {
+                $script:mockInstance |
+                    Add-Member -Force -MemberType 'ScriptMethod' -Name 'Compare' -Value {
+                        return @{
+                            Property      = 'AccessControlList'
+                            ExpectedValue = 'Expected'
+                            ActualValue   = 'Actual'
+                        }
+                    } -PassThru |
+                    Add-Member -Force -MemberType 'ScriptMethod' -Name 'AssertProperties' -Value {
+                        return
+                    }
+            }
+        }
+
+        It 'Should call method Modify()' {
+            InModuleScope -ScriptBlock {
+                $script:mockInstance.Set()
+
+                $script:mockMethodModifyCallCount | Should -Be 1
+            }
+        }
+    }
+}
+
 Describe 'DatabricksClusterPolicyPermission\GetCurrentState()' -Tag 'GetCurrentState' {
     Context 'When permissions exist with all principal types' {
         BeforeAll {

--- a/tests/Unit/Classes/DatabricksResourceBase.Tests.ps1
+++ b/tests/Unit/Classes/DatabricksResourceBase.Tests.ps1
@@ -285,3 +285,157 @@ Describe 'DatabricksResourceBase\InvokeDatabricksApi()' -Tag 'InvokeDatabricksAp
         }
     }
 }
+
+Describe 'DatabricksResourceBase\GetAllResourcesFromApi()' -Tag 'GetAllResourcesFromApi' {
+    Context 'When calling base implementation' {
+        BeforeAll {
+            InModuleScope -ScriptBlock {
+                Mock -CommandName Write-Warning
+
+                $script:mockDatabricksResourceBaseInstance = [DatabricksResourceBase]::new()
+                $script:mockDatabricksResourceBaseInstance.WorkspaceUrl = 'https://adb-1234567890123456.12.azuredatabricks.net'
+                $script:mockDatabricksResourceBaseInstance.AccessToken = ConvertTo-SecureString -String 'dapi1234567890abcdef' -AsPlainText -Force
+            }
+        }
+
+        It 'Should return empty array' {
+            InModuleScope -ScriptBlock {
+                $result = [DatabricksResourceBase]::GetAllResourcesFromApi($script:mockDatabricksResourceBaseInstance)
+
+                $result | Should -HaveCount 0
+            }
+        }
+
+        It 'Should write warning message about not being implemented' {
+            InModuleScope -ScriptBlock {
+                $null = [DatabricksResourceBase]::GetAllResourcesFromApi($script:mockDatabricksResourceBaseInstance)
+
+                Should -Invoke -CommandName Write-Warning -Times 1 -Exactly -Scope It
+            }
+        }
+    }
+}
+
+Describe 'DatabricksResourceBase\CreateExportInstance()' -Tag 'CreateExportInstance' {
+    Context 'When calling base implementation' {
+        BeforeAll {
+            InModuleScope -ScriptBlock {
+                Mock -CommandName Write-Warning
+
+                $script:mockDatabricksResourceBaseInstance = [DatabricksResourceBase]::new()
+                $script:mockDatabricksResourceBaseInstance.WorkspaceUrl = 'https://adb-1234567890123456.12.azuredatabricks.net'
+                $script:mockDatabricksResourceBaseInstance.AccessToken = ConvertTo-SecureString -String 'dapi1234567890abcdef' -AsPlainText -Force
+
+                $script:mockApiData = [PSCustomObject]@{
+                    id   = 'test-123'
+                    name = 'Test Resource'
+                }
+            }
+        }
+
+        It 'Should return null' {
+            InModuleScope -ScriptBlock {
+                $result = [DatabricksResourceBase]::CreateExportInstance($script:mockApiData, $script:mockDatabricksResourceBaseInstance)
+
+                $result | Should -BeNullOrEmpty
+            }
+        }
+
+        It 'Should write warning message about not being implemented' {
+            InModuleScope -ScriptBlock {
+                $null = [DatabricksResourceBase]::CreateExportInstance($script:mockApiData, $script:mockDatabricksResourceBaseInstance)
+
+                Should -Invoke -CommandName Write-Warning -Times 1 -Exactly -Scope It
+            }
+        }
+    }
+}
+
+Describe 'DatabricksResourceBase\Export()' -Tag 'Export' {
+    Context 'When calling parameterless Export() on base class' {
+        BeforeAll {
+            InModuleScope -ScriptBlock {
+                Mock -CommandName Write-Verbose
+                Mock -CommandName Write-Warning
+            }
+        }
+
+        It 'Should return empty array when GetAllResourcesFromApi returns empty' {
+            InModuleScope -ScriptBlock {
+                $result = [DatabricksResourceBase]::Export()
+
+                $result | Should -HaveCount 0
+            }
+        }
+
+        It 'Should call Write-Verbose for exporting and no resources found' {
+            InModuleScope -ScriptBlock {
+                $null = [DatabricksResourceBase]::Export()
+
+                Should -Invoke -CommandName Write-Verbose -Times 2 -Exactly -Scope It
+            }
+        }
+    }
+}
+
+Describe 'DatabricksResourceBase\Export([FilteringInstance])' -Tag 'ExportFiltering' {
+    Context 'When WorkspaceUrl is not set' {
+        BeforeAll {
+            InModuleScope -ScriptBlock {
+                $script:mockInstanceNoUrl = [DatabricksResourceBase]::new()
+                $script:mockInstanceNoUrl.AccessToken = ConvertTo-SecureString -String 'dapi1234567890abcdef' -AsPlainText -Force
+            }
+        }
+
+        It 'Should throw ArgumentException' {
+            InModuleScope -ScriptBlock {
+                { [DatabricksResourceBase]::Export($script:mockInstanceNoUrl) } | Should -Throw -ExpectedMessage '*WorkspaceUrl is required*'
+            }
+        }
+    }
+
+    Context 'When AccessToken is not set' {
+        BeforeAll {
+            InModuleScope -ScriptBlock {
+                $script:mockInstanceNoToken = [DatabricksResourceBase]::new()
+                $script:mockInstanceNoToken.WorkspaceUrl = 'https://adb-1234567890123456.12.azuredatabricks.net'
+            }
+        }
+
+        It 'Should throw ArgumentException' {
+            InModuleScope -ScriptBlock {
+                { [DatabricksResourceBase]::Export($script:mockInstanceNoToken) } | Should -Throw -ExpectedMessage '*AccessToken is required*'
+            }
+        }
+    }
+
+    Context 'When calling Export with valid authentication' {
+        BeforeAll {
+            InModuleScope -ScriptBlock {
+                Mock -CommandName Write-Verbose
+                Mock -CommandName Write-Warning
+
+                $script:mockInstanceValid = [DatabricksResourceBase]::new()
+                $script:mockInstanceValid.WorkspaceUrl = 'https://adb-1234567890123456.12.azuredatabricks.net'
+                $script:mockInstanceValid.AccessToken = ConvertTo-SecureString -String 'dapi1234567890abcdef' -AsPlainText -Force
+            }
+        }
+
+        It 'Should return empty array when GetAllResourcesFromApi returns empty' {
+            InModuleScope -ScriptBlock {
+                $result = [DatabricksResourceBase]::Export($script:mockInstanceValid)
+
+                $result | Should -HaveCount 0
+            }
+        }
+
+        It 'Should call Write-Verbose messages' {
+            InModuleScope -ScriptBlock {
+                $null = [DatabricksResourceBase]::Export($script:mockInstanceValid)
+
+                Should -Invoke -CommandName Write-Verbose -Times 2 -Exactly -Scope It
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
#### Pull Request (PR) description

This PR adds DSC Export capability to the DatabricksDsc module, enabling users to export existing Databricks workspace configurations for use in DSC configurations. The implementation follows the pattern established by other DSC resources like ChocolateyPackage.

**Key Changes:**

- Added Export functionality to `DatabricksResourceBase` class with static methods that child classes can override
- Implemented full Export capability in `DatabricksUser` resource with filtering support
- Added comprehensive unit tests for all Export methods (GetAllResourcesFromApi, CreateExportInstance, Export)
- Improved test coverage by adding missing unit tests for `DatabricksAccountUser` (BuildAccountUserPayload, error handling) and `DatabricksClusterPolicyPermission` (Test, Set methods)

**Export Usage Example:**
```powershell
# Export all users
$instance = [DatabricksUser]::new()
$instance.WorkspaceUrl = 'https://adb-123.azuredatabricks.net'
$instance.AccessToken = $token
$users = [DatabricksUser]::Export($instance)

# Export filtered users
$instance.DisplayName = 'Admin'
$adminUsers = [DatabricksUser]::Export($instance)
```

#### This Pull Request (PR) fixes the following issues

- Fixes #1

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [ ] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
